### PR TITLE
python 3 compatibility

### DIFF
--- a/script/vardiff
+++ b/script/vardiff
@@ -20,7 +20,7 @@
     Paul Medvedev(pashadag@cse.psu.edu)
     Chen Sun(chensun@cse.psu.edu)
 """
-
+from __future__ import print_function
 import sys
 import textwrap as _textwrap
 import argparse
@@ -134,7 +134,7 @@ def read_match_file(filename):
                 continue
             columns = line.split('\t')
             if len(columns) < 2:
-                print line
+                print(line)
             pos = columns[0]+'_'+columns[1]
             pos_set.add(pos)
             donor = columns[3]

--- a/varmatch
+++ b/varmatch
@@ -20,7 +20,7 @@
     Chen Sun(chensun@cse.psu.edu)
     Paul Medvedev(pashadag@cse.psu.edu)
 """
-
+from __future__ import print_function
 import sys
 versionError = "You are using an old version of python, please upgrade to python 2.7+\n"
 if sys.hexversion < 0x02070000:
@@ -358,8 +358,8 @@ def create_stat_html(query_list, output_prefix_list):
         specificity_list.append(z)
         table_list.append(table)
 
-        print sensitivity_table
-        print specificity_table
+        print(sensitivity_table)
+        print(specificity_table)
 
         sensitivity_table_list.append(sensitivity_table)
         specificity_table_list.append(specificity_table)


### PR DESCRIPTION
Varmatch does not run under python3 due to inconsistent use of the print statement.

This patch ensures consistent behavior under both python2 and python3